### PR TITLE
Revert "Periodservice cycles"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: java
 jdk: oraclejdk8
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 notifications:
   slack:
     on_success: change

--- a/build.gradle
+++ b/build.gradle
@@ -12,20 +12,6 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
-javadoc {
-    options.author = true
-    options.addStringOption('Xdoclint:none', '-quiet')
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives javadocJar
-}
-
 repositories {
     jcenter()
     maven { url 'https://jitpack.io' }

--- a/src/main/java/bisq/asset/Asset.java
+++ b/src/main/java/bisq/asset/Asset.java
@@ -19,8 +19,8 @@ package bisq.asset;
 
 /**
  * Interface representing a given ("crypto") asset in its most abstract form, having a
- * {@link #getName() name}, eg "Bitcoin", a {@link #getTickerSymbol() ticker symbol},
- * eg "BTC", and an address validation function. Together, these properties represent
+ * {@link #getName() name}, e.g. "Bitcoin", a {@link #getTickerSymbol() ticker symbol},
+ * e.g. "BTC", and an address validation function. Together, these properties represent
  * the minimum information and functionality required to register and trade an asset on
  * the Bisq network.
  * <p>

--- a/src/main/java/bisq/core/dao/param/DaoParam.java
+++ b/src/main/java/bisq/core/dao/param/DaoParam.java
@@ -50,18 +50,7 @@ public enum DaoParam {
     THRESHOLD_PROPOSAL(5_000),          // 50%
     THRESHOLD_COMP_REQUEST(5_000),      // 50%
     THRESHOLD_CHANGE_PARAM(7_500),      // 75% -> that might change the THRESHOLD_CHANGE_PARAM and QUORUM_CHANGE_PARAM!
-    THRESHOLD_REMOVE_ASSET(5_000),      // 50%
-
-    // Period params, phase lenghts
-    PHASE_UNDEFINED(0), // Must be exactly 0 blocks
-    PHASE_PROPOSAL(5),
-    PHASE_BREAK1(5),
-    PHASE_BLIND_VOTE(5),
-    PHASE_BREAK2(5),
-    PHASE_VOTE_REVEAL(5),
-    PHASE_BREAK3(5),
-    PHASE_ISSUANCE(1), // Must be exactly 1 block
-    PHASE_BREAK4(5);
+    THRESHOLD_REMOVE_ASSET(5_000);      // 50%
 
     @Getter
     private int defaultValue;

--- a/src/main/java/bisq/core/dao/vote/PeriodService.java
+++ b/src/main/java/bisq/core/dao/vote/PeriodService.java
@@ -22,8 +22,8 @@ import bisq.core.dao.blockchain.BsqBlockChain;
 import bisq.core.dao.blockchain.ReadableBsqBlockChain;
 import bisq.core.dao.blockchain.vo.BsqBlock;
 import bisq.core.dao.blockchain.vo.Tx;
-import bisq.core.dao.param.DaoParam;
-import bisq.core.dao.param.DaoParamService;
+
+import bisq.common.app.DevEnv;
 
 import com.google.inject.Inject;
 
@@ -34,10 +34,7 @@ import com.google.common.annotations.VisibleForTesting;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -57,55 +54,45 @@ public class PeriodService implements BsqBlockChain.Listener {
 
     // phase period: 30 days + 30 blocks
     public enum Phase {
-        UNDEFINED, // Must be exactly 0 blocks
-        PROPOSAL,
-        BREAK1,
-        BLIND_VOTE,
-        BREAK2,
-        VOTE_REVEAL,
-        BREAK3,
-        ISSUANCE, // Must be exactly 1 block
-        BREAK4;
-    }
+        // TODO for testing
+        UNDEFINED(0),
+        PROPOSAL(2),
+        BREAK1(1),
+        BLIND_VOTE(2),
+        BREAK2(1),
+        VOTE_REVEAL(2),
+        BREAK3(1),
+        ISSUANCE(1), // Must have only 1 block!
+        BREAK4(1);
 
-    // The default cycle is used as the pre genesis cycle
-    public class Cycle {
-        // Durations of each phase
+      /* UNDEFINED(0),
+        COMPENSATION_REQUESTS(144 * 23),
+        BREAK1(10),
+        BLIND_VOTE(144 * 4),
+        BREAK2(10),
+        VOTE_REVEAL(144 * 3),
+        BREAK3(10);*/
+
+        /**
+         * 144 blocks is 1 day if a block is found each 10 min.
+         */
         @Getter
-        List<Integer> phases = new ArrayList<>();
+        private int durationInBlocks;
 
-        @Getter
-        private int startBlock = 0;
-        @Getter
-        private int lastBlock = 0;
-
-        Cycle(int startBlock, DaoParamService daoParamService) {
-            this.startBlock = startBlock;
-            Arrays.asList(PeriodService.Phase.values()).stream().forEach(phase -> {
-                String name = "PHASE_" + phase.name();
-                phases.add((int) daoParamService.getDaoParamValue(DaoParam.valueOf(name), startBlock));
-            });
-            this.lastBlock = startBlock + getCycleDuration() - 1;
-        }
-
-        public int getCycleDuration() {
-            return getPhases().stream().mapToInt(Integer::intValue).sum();
-        }
-
-        public int getPhaseDuration(PeriodService.Phase phase) {
-            return getPhases().get(phase.ordinal());
+        Phase(int durationInBlocks) {
+            this.durationInBlocks = durationInBlocks;
         }
     }
+
 
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Fields
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private final ReadableBsqBlockChain readableBsqBlockChain;
+    private final int genesisBlockHeight;
     @Getter
     private ObjectProperty<Phase> phaseProperty = new SimpleObjectProperty<>(Phase.UNDEFINED);
-    private List<Cycle> cycles = new ArrayList<>();
-    private DaoParamService daoParamService;
 
 
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -114,13 +101,9 @@ public class PeriodService implements BsqBlockChain.Listener {
 
     @Inject
     public PeriodService(ReadableBsqBlockChain readableBsqBlockChain,
-                         @Named(DaoOptionKeys.GENESIS_BLOCK_HEIGHT) int genesisBlockHeight,
-                         DaoParamService daoParamService) {
+                         @Named(DaoOptionKeys.GENESIS_BLOCK_HEIGHT) int genesisBlockHeight) {
         this.readableBsqBlockChain = readableBsqBlockChain;
-        this.daoParamService = daoParamService;
-
-        // Initialize genesis cycle
-        this.cycles.add(new Cycle(genesisBlockHeight, daoParamService));
+        this.genesisBlockHeight = genesisBlockHeight;
     }
 
 
@@ -141,30 +124,12 @@ public class PeriodService implements BsqBlockChain.Listener {
         onChainHeightChanged(bsqBlock.getHeight());
     }
 
-    public PeriodService.Phase getPhase(int blockHeight) {
-        Cycle cycle = getCycle(blockHeight);
-        if (cycle == null) return Phase.UNDEFINED;
-        int checkHeight = cycle.getStartBlock();
-        List<Integer> phases = cycle.getPhases();
-        for (int i = 0; i < phases.size(); ++i) {
-            if (checkHeight + phases.get(i) > blockHeight)
-                return PeriodService.Phase.values()[i];
-            checkHeight += phases.get(i);
-        }
-        return PeriodService.Phase.UNDEFINED;
-    }
-
-    // Return null for blockHeight < genesis height, it should never happen
-    public Cycle getCycle(int blockHeight) {
-        Optional<Cycle> cycle = cycles.stream().
-                filter(c -> c.getStartBlock() <= blockHeight && blockHeight <= c.getLastBlock()).findAny();
-        if (cycle.isPresent())
-            return cycle.get();
-        return null;
-    }
-
     public boolean isInPhase(int blockHeight, Phase phase) {
-        return getPhase(blockHeight) == phase;
+        int start = getBlockUntilPhaseStart(phase);
+        int end = getBlockUntilPhaseEnd(phase);
+        int numBlocksOfTxHeightSinceGenesis = blockHeight - genesisBlockHeight;
+        int heightInCycle = numBlocksOfTxHeightSinceGenesis % getNumBlocksOfCycle();
+        return heightInCycle >= start && heightInCycle <= end;
     }
 
     // If we are not in the parsing, it is safe to call it without explicit chainHeadHeight
@@ -174,71 +139,60 @@ public class PeriodService implements BsqBlockChain.Listener {
     }
 
     public boolean isTxInCorrectCycle(int txHeight, int chainHeadHeight) {
-        return getCycle(txHeight) == getCycle(chainHeadHeight);
+        return isTxInCorrectCycle(txHeight,
+                chainHeadHeight,
+                genesisBlockHeight,
+                getNumBlocksOfCycle());
     }
 
     public boolean isTxInCorrectCycle(String txId, int chainHeadHeight) {
-        Tx tx = readableBsqBlockChain.getTxMap().get(txId);
-        return tx != null && isTxInCorrectCycle(tx.getBlockHeight(), chainHeadHeight);
-    }
-
-    public boolean isTxInCurrentCycle(String txId) {
-        Tx tx = readableBsqBlockChain.getTxMap().get(txId);
-        return tx != null && getCycle(tx.getBlockHeight()) == getCycle(readableBsqBlockChain.getChainHeadHeight());
-    }
-
-    public boolean isTxInPastCycle(String txId) {
-        Tx tx = readableBsqBlockChain.getTxMap().get(txId);
-        return tx != null && getCycle(tx.getBlockHeight()).getStartBlock() <
-                getCycle(readableBsqBlockChain.getChainHeadHeight()).getStartBlock();
-    }
-
-    public boolean isTxInPastCycle(Tx tx, int chainHeadHeight) {
-        return getCycle(tx.getBlockHeight()).startBlock < getCycle(chainHeadHeight).startBlock;
+        return readableBsqBlockChain.getTx(txId)
+                .filter(tx -> isTxInCorrectCycle(tx.getBlockHeight(), chainHeadHeight))
+                .isPresent();
     }
 
     public boolean isTxInPastCycle(String txId, int chainHeadHeight) {
         return readableBsqBlockChain.getTx(txId).filter(tx -> isTxInPastCycle(tx, chainHeadHeight)).isPresent();
     }
 
-    public int getNumberOfStartedCycles() {
-        // There is one dummy cycle added before the genesis cycle
-        return cycles.size();
+    public boolean isTxInPastCycle(Tx tx, int chainHeadHeight) {
+        return isTxInPastCycle(tx.getBlockHeight(),
+                chainHeadHeight,
+                genesisBlockHeight,
+                getNumBlocksOfCycle());
     }
 
-//    public int getNumOfCompletedCycles(int chainHeight) {
-//        Cycle lastCycle = getCycle(chainHeight);
-//        if (lastCycle.getStartBlock() + lastCycle.getCycleDuration() == chainHeight)
-//            return getNumberOfStartedCycles();
-//        return getNumberOfStartedCycles() - 1;
-//    }
-
-    // Get first block of phase within the given cycle
-    public int getFirstBlockOfPhase(Cycle cycle, Phase phase) {
-        int checkHeight = cycle.getStartBlock();
-        List<Integer> phases = cycle.getPhases();
-        for (int i = 0; i < phases.size(); ++i) {
-            if (i == phase.ordinal()) {
-                return checkHeight;
-            }
-            checkHeight += phases.get(i);
-        }
-        // Can't handle future phases until cycle is defined
-        return 0;
+    public int getNumOfStartedCycles(int chainHeight) {
+        return getNumOfStartedCycles(chainHeight,
+                genesisBlockHeight,
+                getNumBlocksOfCycle());
     }
 
-    // Get last block of phase within the given cycle
-    public int getLastBlockOfPhase(Cycle cycle, Phase phase) {
-        int checkHeight = cycle.getStartBlock();
-        List<Integer> phases = cycle.getPhases();
-        for (int i = 0; i < phases.size(); ++i) {
-            if (i == phase.ordinal()) {
-                return checkHeight + phases.get(i) - 1;
-            }
-            checkHeight += phases.get(i);
-        }
-        // Can't handle future phases until cycle is defined
-        return 0;
+    // Not used yet be leave it
+    public int getNumOfCompletedCycles(int chainHeight) {
+        return getNumOfCompletedCycles(chainHeight,
+                genesisBlockHeight,
+                getNumBlocksOfCycle());
+    }
+
+    public Phase getPhaseForHeight(int chainHeight) {
+        int startOfCurrentCycle = getAbsoluteStartBlockOfCycle(chainHeight, genesisBlockHeight, getNumBlocksOfCycle());
+        int offset = chainHeight - startOfCurrentCycle;
+        return calculatePhase(offset);
+    }
+
+    public int getAbsoluteStartBlockOfPhase(int chainHeight, Phase phase) {
+        return getAbsoluteStartBlockOfPhase(chainHeight,
+                genesisBlockHeight,
+                phase,
+                getNumBlocksOfCycle());
+    }
+
+    public int getAbsoluteEndBlockOfPhase(int chainHeight, Phase phase) {
+        return getAbsoluteEndBlockOfPhase(chainHeight,
+                genesisBlockHeight,
+                phase,
+                getNumBlocksOfCycle());
     }
 
 
@@ -246,13 +200,161 @@ public class PeriodService implements BsqBlockChain.Listener {
     // Private methods
     ///////////////////////////////////////////////////////////////////////////////////////////
 
+    private void onChainHeightChanged(int chainHeight) {
+        final int relativeBlocksInCycle = getRelativeBlocksInCycle(genesisBlockHeight, chainHeight, getNumBlocksOfCycle());
+        phaseProperty.set(calculatePhase(relativeBlocksInCycle));
+    }
+
     @VisibleForTesting
-    void onChainHeightChanged(int chainHeight) {
-        Cycle lastCycle = cycles.get(cycles.size() - 1);
-        while (chainHeight >= lastCycle.getLastBlock()) {
-            cycles.add(new Cycle(lastCycle.getLastBlock() + 1, daoParamService));
-            lastCycle = cycles.get(cycles.size() - 1);
+    int getRelativeBlocksInCycle(int genesisHeight, int bestChainHeight, int numBlocksOfCycle) {
+        return (bestChainHeight - genesisHeight) % numBlocksOfCycle;
+    }
+
+    int getBlockUntilPhaseStart(Phase target) {
+        int totalDuration = 0;
+        for (Phase phase : Arrays.asList(Phase.values())) {
+            if (phase == target)
+                break;
+            else
+                totalDuration += phase.getDurationInBlocks();
         }
-        phaseProperty.set(getPhase(chainHeight));
+        return totalDuration;
+    }
+
+    int getBlockUntilPhaseEnd(Phase target) {
+        int totalDuration = 0;
+        for (Phase phase : Arrays.asList(Phase.values())) {
+            totalDuration += phase.getDurationInBlocks();
+            if (phase == target)
+                break;
+        }
+        return totalDuration;
+    }
+
+    @VisibleForTesting
+    Phase calculatePhase(int blocksInNewPhase) {
+        if (blocksInNewPhase < Phase.PROPOSAL.getDurationInBlocks())
+            return Phase.PROPOSAL;
+        else if (blocksInNewPhase < Phase.PROPOSAL.getDurationInBlocks() +
+                Phase.BREAK1.getDurationInBlocks())
+            return Phase.BREAK1;
+        else if (blocksInNewPhase < Phase.PROPOSAL.getDurationInBlocks() +
+                Phase.BREAK1.getDurationInBlocks() +
+                Phase.BLIND_VOTE.getDurationInBlocks())
+            return Phase.BLIND_VOTE;
+        else if (blocksInNewPhase < Phase.PROPOSAL.getDurationInBlocks() +
+                Phase.BREAK1.getDurationInBlocks() +
+                Phase.BLIND_VOTE.getDurationInBlocks() +
+                Phase.BREAK2.getDurationInBlocks())
+            return Phase.BREAK2;
+        else if (blocksInNewPhase < Phase.PROPOSAL.getDurationInBlocks() +
+                Phase.BREAK1.getDurationInBlocks() +
+                Phase.BLIND_VOTE.getDurationInBlocks() +
+                Phase.BREAK2.getDurationInBlocks() +
+                Phase.VOTE_REVEAL.getDurationInBlocks())
+            return Phase.VOTE_REVEAL;
+        else if (blocksInNewPhase < Phase.PROPOSAL.getDurationInBlocks() +
+                Phase.BREAK1.getDurationInBlocks() +
+                Phase.BLIND_VOTE.getDurationInBlocks() +
+                Phase.BREAK2.getDurationInBlocks() +
+                Phase.VOTE_REVEAL.getDurationInBlocks() +
+                Phase.BREAK3.getDurationInBlocks())
+            return Phase.BREAK3;
+        else if (blocksInNewPhase < Phase.PROPOSAL.getDurationInBlocks() +
+                Phase.BREAK1.getDurationInBlocks() +
+                Phase.BLIND_VOTE.getDurationInBlocks() +
+                Phase.BREAK2.getDurationInBlocks() +
+                Phase.VOTE_REVEAL.getDurationInBlocks() +
+                Phase.BREAK3.getDurationInBlocks() +
+                Phase.ISSUANCE.getDurationInBlocks())
+            return Phase.ISSUANCE;
+        else if (blocksInNewPhase < Phase.PROPOSAL.getDurationInBlocks() +
+                Phase.BREAK1.getDurationInBlocks() +
+                Phase.BLIND_VOTE.getDurationInBlocks() +
+                Phase.BREAK2.getDurationInBlocks() +
+                Phase.VOTE_REVEAL.getDurationInBlocks() +
+                Phase.BREAK3.getDurationInBlocks() +
+                Phase.ISSUANCE.getDurationInBlocks() +
+                Phase.BREAK4.getDurationInBlocks())
+            return Phase.BREAK4;
+        else {
+            log.error("blocksInNewPhase is not covered by phase checks. blocksInNewPhase={}", blocksInNewPhase);
+            if (DevEnv.isDevMode())
+                throw new RuntimeException("blocksInNewPhase is not covered by phase checks. blocksInNewPhase=" + blocksInNewPhase);
+            else
+                return Phase.UNDEFINED;
+        }
+    }
+
+    @VisibleForTesting
+    boolean isTxInCorrectCycle(int txHeight, int chainHeight, int genesisHeight, int numBlocksOfCycle) {
+        final int numOfCompletedCycles = getNumOfCompletedCycles(chainHeight, genesisHeight, numBlocksOfCycle);
+        final int blockAtCycleStart = genesisHeight + numOfCompletedCycles * numBlocksOfCycle;
+        final int blockAtCycleEnd = blockAtCycleStart + numBlocksOfCycle - 1;
+        return txHeight <= chainHeight &&
+                chainHeight >= genesisHeight &&
+                txHeight >= blockAtCycleStart &&
+                txHeight <= blockAtCycleEnd;
+    }
+
+    @VisibleForTesting
+    boolean isTxInPastCycle(int txHeight, int chainHeight, int genesisHeight, int numBlocksOfCycle) {
+        final int numOfCompletedCycles = getNumOfCompletedCycles(chainHeight, genesisHeight, numBlocksOfCycle);
+        final int blockAtCycleStart = genesisHeight + numOfCompletedCycles * numBlocksOfCycle;
+        return txHeight <= chainHeight &&
+                chainHeight >= genesisHeight &&
+                txHeight <= blockAtCycleStart;
+    }
+
+    @VisibleForTesting
+    int getAbsoluteStartBlockOfPhase(int chainHeight, int genesisHeight, Phase phase, int numBlocksOfCycle) {
+        return genesisHeight + getNumOfCompletedCycles(chainHeight, genesisHeight, numBlocksOfCycle) * getNumBlocksOfCycle() + getNumBlocksOfPhaseStart(phase);
+    }
+
+    @VisibleForTesting
+    int getAbsoluteStartBlockOfCycle(int chainHeight, int genesisHeight, int numBlocksOfCycle) {
+        return genesisHeight + getNumOfCompletedCycles(chainHeight, genesisHeight, numBlocksOfCycle) * getNumBlocksOfCycle() + getNumBlocksOfPhaseStart(Phase.PROPOSAL);
+    }
+
+    @VisibleForTesting
+    int getAbsoluteEndBlockOfPhase(int chainHeight, int genesisHeight, Phase phase, int numBlocksOfCycle) {
+        return getAbsoluteStartBlockOfPhase(chainHeight, genesisHeight, phase, numBlocksOfCycle) + phase.getDurationInBlocks() - 1;
+    }
+
+    @VisibleForTesting
+    int getNumOfStartedCycles(int chainHeight, int genesisHeight, int numBlocksOfCycle) {
+        if (chainHeight >= genesisHeight)
+            return getNumOfCompletedCycles(chainHeight, genesisHeight, numBlocksOfCycle) + 1;
+        else
+            return 0;
+    }
+
+    int getNumOfCompletedCycles(int chainHeight, int genesisHeight, int numBlocksOfCycle) {
+        if (chainHeight >= genesisHeight && numBlocksOfCycle > 0)
+            return (chainHeight - genesisHeight) / numBlocksOfCycle;
+        else
+            return 0;
+    }
+
+    @VisibleForTesting
+    int getNumBlocksOfPhaseStart(Phase phase) {
+        int blocks = 0;
+        for (int i = 0; i < Phase.values().length; i++) {
+            final Phase currentPhase = Phase.values()[i];
+            if (currentPhase == phase)
+                break;
+
+            blocks += currentPhase.getDurationInBlocks();
+        }
+        return blocks;
+    }
+
+    @VisibleForTesting
+    int getNumBlocksOfCycle() {
+        int blocks = 0;
+        for (int i = 0; i < Phase.values().length; i++) {
+            blocks += Phase.values()[i].getDurationInBlocks();
+        }
+        return blocks;
     }
 }

--- a/src/main/java/bisq/core/dao/vote/voteresult/VoteResultService.java
+++ b/src/main/java/bisq/core/dao/vote/voteresult/VoteResultService.java
@@ -127,7 +127,7 @@ public class VoteResultService implements BsqBlockChain.Listener {
     ///////////////////////////////////////////////////////////////////////////////////////////
 
     private void maybeApplyVoteResult(int chainHeight) {
-        if (periodService.getPhase(chainHeight) == PeriodService.Phase.ISSUANCE) {
+        if (periodService.getPhaseForHeight(chainHeight) == PeriodService.Phase.ISSUANCE) {
             applyVoteResult(chainHeight);
         }
     }

--- a/src/main/java/bisq/core/dao/vote/votereveal/VoteRevealService.java
+++ b/src/main/java/bisq/core/dao/vote/votereveal/VoteRevealService.java
@@ -118,7 +118,7 @@ public class VoteRevealService implements BsqBlockChain.Listener {
 
     @Override
     public void onBlockAdded(BsqBlock bsqBlock) {
-        if (periodService.getPhase(bsqBlock.getHeight()) == PeriodService.Phase.VOTE_REVEAL) {
+        if (periodService.getPhaseForHeight(bsqBlock.getHeight()) == PeriodService.Phase.VOTE_REVEAL) {
             // A phase change is triggered by a new block but we need to wait for the parser to complete
             //TODO use handler only triggered at end of parsing. -> Refactor bsqBlockChain and BsqNode handlers
             maybeRevealVotes(bsqBlock.getHeight());

--- a/src/main/java/bisq/core/offer/OfferUtil.java
+++ b/src/main/java/bisq/core/offer/OfferUtil.java
@@ -40,6 +40,9 @@ public class OfferUtil {
 
     /**
      * Given the direction, is this a BUY?
+     *
+     * @param direction
+     * @return
      */
     public static boolean isBuyOffer(OfferPayload.Direction direction) {
         return direction == OfferPayload.Direction.BUY;
@@ -48,7 +51,12 @@ public class OfferUtil {
     /**
      * Returns the makerFee as Coin, this can be priced in BTC or BSQ.
      *
-     * @param preferences preferences are used to see if the user indicated a preference for paying fees in BTC
+     * @param bsqWalletService
+     * @param preferences          preferences are used to see if the user indicated a preference for paying fees in BTC
+     * @param amount
+     * @param marketPriceAvailable
+     * @param marketPriceMargin
+     * @return
      */
     @Nullable
     public static Coin getMakerFee(BsqWalletService bsqWalletService, Preferences preferences, Coin amount, boolean marketPriceAvailable, double marketPriceMargin) {
@@ -61,6 +69,12 @@ public class OfferUtil {
 
     /**
      * Calculates the maker fee for the given amount, marketPrice and marketPriceMargin.
+     *
+     * @param isCurrencyForMakerFeeBtc
+     * @param amount
+     * @param marketPriceAvailable
+     * @param marketPriceMargin
+     * @return
      */
     @Nullable
     public static Coin getMakerFee(boolean isCurrencyForMakerFeeBtc, @Nullable Coin amount, boolean marketPriceAvailable, double marketPriceMargin) {
@@ -87,6 +101,13 @@ public class OfferUtil {
     /**
      * Checks if the maker fee should be paid in BTC, this can be the case due to user preference or because the user
      * doesn't have enough BSQ.
+     *
+     * @param preferences
+     * @param bsqWalletService
+     * @param amount
+     * @param marketPriceAvailable
+     * @param marketPriceMargin
+     * @return
      */
     public static boolean isCurrencyForMakerFeeBtc(Preferences preferences, BsqWalletService bsqWalletService, Coin amount, boolean marketPriceAvailable, double marketPriceMargin) {
         return preferences.getPayFeeInBtc() ||
@@ -95,6 +116,12 @@ public class OfferUtil {
 
     /**
      * Checks if the available BSQ balance is sufficient to pay for the offer's maker fee.
+     *
+     * @param bsqWalletService
+     * @param amount
+     * @param marketPriceAvailable
+     * @param marketPriceMargin
+     * @return
      */
     public static boolean isBsqForFeeAvailable(BsqWalletService bsqWalletService, @Nullable Coin amount, boolean marketPriceAvailable, double marketPriceMargin) {
         final Coin makerFee = getMakerFee(false, amount, marketPriceAvailable, marketPriceMargin);

--- a/src/test/java/bisq/core/dao/vote/PeriodServiceTest.java
+++ b/src/test/java/bisq/core/dao/vote/PeriodServiceTest.java
@@ -17,108 +17,20 @@
 
 package bisq.core.dao.vote;
 
-import bisq.core.dao.blockchain.ReadableBsqBlockChain;
-import bisq.core.dao.param.DaoParam;
-import bisq.core.dao.param.DaoParamService;
-
-import org.powermock.core.classloader.annotations.PrepareForTest;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-@PrepareForTest({DaoParamService.class})
 public class PeriodServiceTest {
 
     private PeriodService service;
-    private int genesisHeight = 200;
-    DaoParamService daoParamService = mock(DaoParamService.class);
-    ReadableBsqBlockChain readableBsqBlockChain = mock(ReadableBsqBlockChain.class);
-    // All phases are 10 blocks long during test
-    long phaseDuration = 10L;
 
     @Before
     public void startup() {
-        when(daoParamService.getDaoParamValue(any(DaoParam.class), anyInt())).thenReturn(phaseDuration);
-        when(daoParamService.getDaoParamValue(eq(DaoParam.PHASE_UNDEFINED), anyInt())).thenReturn(0L);
-        when(daoParamService.getDaoParamValue(eq(DaoParam.PHASE_ISSUANCE), anyInt())).thenReturn(1L);
-
-        service = new PeriodService(readableBsqBlockChain, genesisHeight, daoParamService);
-    }
-
-    @Test
-    public void getCycle() {
-        int newCycleStartBlock = genesisHeight + service.getCycle(genesisHeight).getCycleDuration();
-        service.onChainHeightChanged(newCycleStartBlock);
-        assertEquals(service.getCycle(genesisHeight), service.getCycle(newCycleStartBlock - 1));
-        assertEquals(service.getCycle(newCycleStartBlock), service.getCycle(newCycleStartBlock + 1));
-        assertEquals(null, service.getCycle(0));
-        assertEquals(null, service.getCycle(genesisHeight - 1));
-        assertEquals(phaseDuration, service.getCycle(genesisHeight).getPhaseDuration(PeriodService.Phase.PROPOSAL));
-        assertEquals(newCycleStartBlock, service.getCycle(newCycleStartBlock).getStartBlock());
-        int lastBlockOfNewCycle = newCycleStartBlock + service.getCycle(newCycleStartBlock).getCycleDuration() - 1;
-        // Should add another cycle when reaching last block of the last cycle
-        service.onChainHeightChanged(lastBlockOfNewCycle);
-        assertEquals(lastBlockOfNewCycle + 1,
-                service.getCycle(lastBlockOfNewCycle + 1).getStartBlock());
-    }
-
-
-    @Test
-    public void getPhase() {
-        int newCycleStartBlock = service.getCycle(genesisHeight).getLastBlock() + 1;
-        service.onChainHeightChanged(newCycleStartBlock);
-        assertEquals(PeriodService.Phase.PROPOSAL, service.getPhase(genesisHeight));
-        assertEquals(PeriodService.Phase.PROPOSAL,
-                service.getPhase(genesisHeight + (int) phaseDuration - 1));
-        assertEquals(PeriodService.Phase.BREAK1, service.getPhase(genesisHeight + (int) phaseDuration));
-        assertEquals(PeriodService.Phase.BREAK4,
-                service.getPhase(genesisHeight + service.getCycle(genesisHeight).getCycleDuration() - 1));
-        assertEquals(PeriodService.Phase.PROPOSAL,
-                service.getPhase(genesisHeight + service.getCycle(genesisHeight).getCycleDuration()));
-    }
-
-    @Test
-    public void getStartBlockOfPhase() {
-        PeriodService.Cycle c = service.getCycle(genesisHeight);
-        assertEquals(genesisHeight, service.getFirstBlockOfPhase(service.getCycle(genesisHeight), PeriodService.Phase.PROPOSAL));
-        assertEquals(genesisHeight + phaseDuration,
-                service.getFirstBlockOfPhase(service.getCycle(genesisHeight), PeriodService.Phase.BREAK1));
-    }
-
-    @Test
-    public void getEndBlockOfPhase() {
-        int newCycleStartBlock = service.getCycle(genesisHeight).getLastBlock() + 1;
-        service.onChainHeightChanged(newCycleStartBlock);
-        PeriodService.Cycle c = service.getCycle(genesisHeight);
-        assertEquals(genesisHeight + phaseDuration - 1,
-                service.getLastBlockOfPhase(service.getCycle(genesisHeight), PeriodService.Phase.PROPOSAL));
-        assertEquals(genesisHeight + 2 * phaseDuration - 1,
-                service.getLastBlockOfPhase(service.getCycle(genesisHeight), PeriodService.Phase.BREAK1));
-    }
-
-    @Test
-    public void getNumberOfStartedCycles() {
-        int newCycleStartBlock = service.getCycle(genesisHeight).getLastBlock() + 1;
-        service.onChainHeightChanged(newCycleStartBlock);
-        assertEquals(2, service.getNumberOfStartedCycles());
-    }
-
-    @Test
-    public void onChainHeightChanged() {
-        int newCycleStartBlock = service.getCycle(genesisHeight).getLastBlock() + 1;
-        service.onChainHeightChanged(newCycleStartBlock);
-        assertNotEquals(service.getCycle(genesisHeight), service.getCycle(newCycleStartBlock));
+        service = new PeriodService(null, 0);
     }
 
     //TODO update with added periods
@@ -132,124 +44,124 @@ public class PeriodServiceTest {
               phase5  VOTE_REVEAL(144 * 3), // 3908 + 432 = 4340
               phase6  BREAK3(10); 4350
         */
-//        int totalPhaseBlocks = service.getNumBlocksOfCycle();
+        int totalPhaseBlocks = service.getNumBlocksOfCycle();
 
-//        int phase1 = Cycles.Phase.PROPOSAL.getCycleDuration();
-//        int phase2 = phase1 + Cycles.Phase.BREAK1.getCycleDuration();
-//        int phase3 = phase2 + Cycles.Phase.BLIND_VOTE.getCycleDuration();
-//        int phase4 = phase3 + Cycles.Phase.BREAK2.getCycleDuration();
-//        int phase5 = phase4 + Cycles.Phase.VOTE_REVEAL.getCycleDuration();
-//        int phase6 = phase5 + Cycles.Phase.BREAK3.getCycleDuration();
+        int phase1 = PeriodService.Phase.PROPOSAL.getDurationInBlocks();
+        int phase2 = phase1 + PeriodService.Phase.BREAK1.getDurationInBlocks();
+        int phase3 = phase2 + PeriodService.Phase.BLIND_VOTE.getDurationInBlocks();
+        int phase4 = phase3 + PeriodService.Phase.BREAK2.getDurationInBlocks();
+        int phase5 = phase4 + PeriodService.Phase.VOTE_REVEAL.getDurationInBlocks();
+        int phase6 = phase5 + PeriodService.Phase.BREAK3.getDurationInBlocks();
 
-//        assertEquals(Cycles.Phase.PROPOSAL, service.calculatePhase(service.getRelativeBlocksInCycle(0, 0, totalPhaseBlocks)));
-//        assertEquals(Cycles.Phase.PROPOSAL, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase1 - 1, totalPhaseBlocks)));
-//        assertEquals(Cycles.Phase.BREAK1, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase1, totalPhaseBlocks)));
-//        assertEquals(Cycles.Phase.BREAK1, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase2 - 1, totalPhaseBlocks)));
-//        assertEquals(Cycles.Phase.BLIND_VOTE, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase2, totalPhaseBlocks)));
-//        assertEquals(Cycles.Phase.BLIND_VOTE, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase3 - 1, totalPhaseBlocks)));
-//        assertEquals(Cycles.Phase.BREAK2, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase3, totalPhaseBlocks)));
-//        assertEquals(Cycles.Phase.BREAK2, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase4 - 1, totalPhaseBlocks)));
-//        assertEquals(Cycles.Phase.VOTE_REVEAL, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase4, totalPhaseBlocks)));
-//        assertEquals(Cycles.Phase.VOTE_REVEAL, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase5 - 1, totalPhaseBlocks)));
-//        assertEquals(Cycles.Phase.BREAK3, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase5, totalPhaseBlocks)));
-//        assertEquals(Cycles.Phase.BREAK3, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase6 - 1, totalPhaseBlocks)));
-//        assertEquals(Cycles.Phase.ISSUANCE, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase6, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.PROPOSAL, service.calculatePhase(service.getRelativeBlocksInCycle(0, 0, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.PROPOSAL, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase1 - 1, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.BREAK1, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase1, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.BREAK1, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase2 - 1, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.BLIND_VOTE, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase2, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.BLIND_VOTE, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase3 - 1, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.BREAK2, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase3, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.BREAK2, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase4 - 1, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.VOTE_REVEAL, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase4, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.VOTE_REVEAL, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase5 - 1, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.BREAK3, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase5, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.BREAK3, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase6 - 1, totalPhaseBlocks)));
+        assertEquals(PeriodService.Phase.ISSUANCE, service.calculatePhase(service.getRelativeBlocksInCycle(0, phase6, totalPhaseBlocks)));
     }
 
     @Test
     public void getNumOfStartedCyclesTest() {
         // int chainHeight, int genesisHeight, int numBlocksOfCycle
-//        int numBlocksOfCycle = service.getNumBlocksOfCycle();
-//        int genesisHeight = 1;
-//        assertEquals(0, service.getNumOfStartedCycles(genesisHeight - 1, genesisHeight, numBlocksOfCycle));
-//        assertEquals(1, service.getNumOfStartedCycles(genesisHeight, genesisHeight, numBlocksOfCycle));
-//        assertEquals(1, service.getNumOfStartedCycles(genesisHeight + 1, genesisHeight, numBlocksOfCycle));
-//        assertEquals(1, service.getNumOfStartedCycles(genesisHeight + numBlocksOfCycle - 1, genesisHeight, numBlocksOfCycle));
-//        assertEquals(2, service.getNumOfStartedCycles(genesisHeight + numBlocksOfCycle, genesisHeight, numBlocksOfCycle));
-//        assertEquals(2, service.getNumOfStartedCycles(genesisHeight + numBlocksOfCycle + 1, genesisHeight, numBlocksOfCycle));
-//        assertEquals(2, service.getNumOfStartedCycles(genesisHeight + numBlocksOfCycle + numBlocksOfCycle - 1, genesisHeight, numBlocksOfCycle));
-//        assertEquals(3, service.getNumOfStartedCycles(genesisHeight + numBlocksOfCycle + numBlocksOfCycle, genesisHeight, numBlocksOfCycle));
+        int numBlocksOfCycle = service.getNumBlocksOfCycle();
+        int genesisHeight = 1;
+        assertEquals(0, service.getNumOfStartedCycles(genesisHeight - 1, genesisHeight, numBlocksOfCycle));
+        assertEquals(1, service.getNumOfStartedCycles(genesisHeight, genesisHeight, numBlocksOfCycle));
+        assertEquals(1, service.getNumOfStartedCycles(genesisHeight + 1, genesisHeight, numBlocksOfCycle));
+        assertEquals(1, service.getNumOfStartedCycles(genesisHeight + numBlocksOfCycle - 1, genesisHeight, numBlocksOfCycle));
+        assertEquals(2, service.getNumOfStartedCycles(genesisHeight + numBlocksOfCycle, genesisHeight, numBlocksOfCycle));
+        assertEquals(2, service.getNumOfStartedCycles(genesisHeight + numBlocksOfCycle + 1, genesisHeight, numBlocksOfCycle));
+        assertEquals(2, service.getNumOfStartedCycles(genesisHeight + numBlocksOfCycle + numBlocksOfCycle - 1, genesisHeight, numBlocksOfCycle));
+        assertEquals(3, service.getNumOfStartedCycles(genesisHeight + numBlocksOfCycle + numBlocksOfCycle, genesisHeight, numBlocksOfCycle));
     }
 
     @Test
     public void getNumOfCompletedCyclesTest() {
         // int chainHeight, int genesisHeight, int totalPeriodInBlocks
-//        int numBlocksOfCycle = service.getNumBlocksOfCycle();
-//        int genesisHeight = 1;
-//        assertEquals(0, service.getNumOfCompletedCycles(genesisHeight - 1, genesisHeight, numBlocksOfCycle));
-//        assertEquals(0, service.getNumOfCompletedCycles(genesisHeight, genesisHeight, numBlocksOfCycle));
-//        assertEquals(0, service.getNumOfCompletedCycles(genesisHeight + 1, genesisHeight, numBlocksOfCycle));
-//        assertEquals(0, service.getNumOfCompletedCycles(genesisHeight + numBlocksOfCycle - 1, genesisHeight, numBlocksOfCycle));
-//        assertEquals(1, service.getNumOfCompletedCycles(genesisHeight + numBlocksOfCycle, genesisHeight, numBlocksOfCycle));
-//        assertEquals(1, service.getNumOfCompletedCycles(genesisHeight + numBlocksOfCycle + 1, genesisHeight, numBlocksOfCycle));
-//        assertEquals(1, service.getNumOfCompletedCycles(genesisHeight + numBlocksOfCycle + numBlocksOfCycle - 1, genesisHeight, numBlocksOfCycle));
-//        assertEquals(2, service.getNumOfCompletedCycles(genesisHeight + numBlocksOfCycle + numBlocksOfCycle, genesisHeight, numBlocksOfCycle));
+        int numBlocksOfCycle = service.getNumBlocksOfCycle();
+        int genesisHeight = 1;
+        assertEquals(0, service.getNumOfCompletedCycles(genesisHeight - 1, genesisHeight, numBlocksOfCycle));
+        assertEquals(0, service.getNumOfCompletedCycles(genesisHeight, genesisHeight, numBlocksOfCycle));
+        assertEquals(0, service.getNumOfCompletedCycles(genesisHeight + 1, genesisHeight, numBlocksOfCycle));
+        assertEquals(0, service.getNumOfCompletedCycles(genesisHeight + numBlocksOfCycle - 1, genesisHeight, numBlocksOfCycle));
+        assertEquals(1, service.getNumOfCompletedCycles(genesisHeight + numBlocksOfCycle, genesisHeight, numBlocksOfCycle));
+        assertEquals(1, service.getNumOfCompletedCycles(genesisHeight + numBlocksOfCycle + 1, genesisHeight, numBlocksOfCycle));
+        assertEquals(1, service.getNumOfCompletedCycles(genesisHeight + numBlocksOfCycle + numBlocksOfCycle - 1, genesisHeight, numBlocksOfCycle));
+        assertEquals(2, service.getNumOfCompletedCycles(genesisHeight + numBlocksOfCycle + numBlocksOfCycle, genesisHeight, numBlocksOfCycle));
     }
 
     //TODO update with added periods
     @Test
     public void getCompensationRequestStartBlockTest() {
         // int chainHeight, int genesisHeight, int totalPeriodInBlocks
-//        int numBlocksOfCycle = service.getNumBlocksOfCycle();
-//        int gen = 1;
-//        final int first = gen; // 1
-//        final int second = first + numBlocksOfCycle; //
-//        final int third = first + numBlocksOfCycle + numBlocksOfCycle; //
-//        assertEquals(gen, service.getFirstBlockOfPhase(0, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(gen, service.getFirstBlockOfPhase(gen, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(first, service.getFirstBlockOfPhase(gen + 1, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(first, service.getFirstBlockOfPhase(gen + numBlocksOfCycle - 1, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(second, service.getFirstBlockOfPhase(gen + numBlocksOfCycle, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(second, service.getFirstBlockOfPhase(gen + numBlocksOfCycle + 1, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(second, service.getFirstBlockOfPhase(gen + numBlocksOfCycle + numBlocksOfCycle - 1, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(third, service.getFirstBlockOfPhase(gen + numBlocksOfCycle + numBlocksOfCycle, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
+        int numBlocksOfCycle = service.getNumBlocksOfCycle();
+        int gen = 1;
+        final int first = gen; // 1
+        final int second = first + numBlocksOfCycle; //
+        final int third = first + numBlocksOfCycle + numBlocksOfCycle; //
+        assertEquals(gen, service.getAbsoluteStartBlockOfPhase(0, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(gen, service.getAbsoluteStartBlockOfPhase(gen, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(first, service.getAbsoluteStartBlockOfPhase(gen + 1, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(first, service.getAbsoluteStartBlockOfPhase(gen + numBlocksOfCycle - 1, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(second, service.getAbsoluteStartBlockOfPhase(gen + numBlocksOfCycle, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(second, service.getAbsoluteStartBlockOfPhase(gen + numBlocksOfCycle + 1, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(second, service.getAbsoluteStartBlockOfPhase(gen + numBlocksOfCycle + numBlocksOfCycle - 1, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(third, service.getAbsoluteStartBlockOfPhase(gen + numBlocksOfCycle + numBlocksOfCycle, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
     }
 
     //TODO update with added periods
     @Test
     public void getCompensationRequestEndBlockTest() {
         // int chainHeight, int genesisHeight, int numBlocksOfCycle, int totalPeriodInBlocks
-//        int blocks = Cycles.Phase.PROPOSAL.getCycleDuration(); //10
-//        int numBlocksOfCycle = service.getNumBlocksOfCycle();
-//        int gen = 1;
-//        final int first = gen + blocks - 1; //10
-//        final int second = first + numBlocksOfCycle; // 30
-//        final int third = first + numBlocksOfCycle + numBlocksOfCycle; //40
-//        assertEquals(first, service.getLastBlockOfPhase(0, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(first, service.getLastBlockOfPhase(gen, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(first, service.getLastBlockOfPhase(gen + 1, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(first, service.getLastBlockOfPhase(gen + numBlocksOfCycle - 1, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(second, service.getLastBlockOfPhase(gen + numBlocksOfCycle, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(second, service.getLastBlockOfPhase(gen + numBlocksOfCycle + 1, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(second, service.getLastBlockOfPhase(gen + numBlocksOfCycle + numBlocksOfCycle - 1, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
-//        assertEquals(third, service.getLastBlockOfPhase(gen + numBlocksOfCycle + numBlocksOfCycle, gen, Cycles.Phase.PROPOSAL, numBlocksOfCycle));
+        int blocks = PeriodService.Phase.PROPOSAL.getDurationInBlocks(); //10
+        int numBlocksOfCycle = service.getNumBlocksOfCycle();
+        int gen = 1;
+        final int first = gen + blocks - 1; //10
+        final int second = first + numBlocksOfCycle; // 30
+        final int third = first + numBlocksOfCycle + numBlocksOfCycle; //40
+        assertEquals(first, service.getAbsoluteEndBlockOfPhase(0, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(first, service.getAbsoluteEndBlockOfPhase(gen, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(first, service.getAbsoluteEndBlockOfPhase(gen + 1, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(first, service.getAbsoluteEndBlockOfPhase(gen + numBlocksOfCycle - 1, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(second, service.getAbsoluteEndBlockOfPhase(gen + numBlocksOfCycle, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(second, service.getAbsoluteEndBlockOfPhase(gen + numBlocksOfCycle + 1, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(second, service.getAbsoluteEndBlockOfPhase(gen + numBlocksOfCycle + numBlocksOfCycle - 1, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
+        assertEquals(third, service.getAbsoluteEndBlockOfPhase(gen + numBlocksOfCycle + numBlocksOfCycle, gen, PeriodService.Phase.PROPOSAL, numBlocksOfCycle));
     }
 
     //TODO update with added periods
     @Test
     public void getStartBlockOfPhaseTest() {
-//        assertEquals(0, service.getNumBlocksOfPhaseStart(Cycles.Phase.PROPOSAL));
-//        assertEquals(Cycles.Phase.PROPOSAL.getCycleDuration(),
-//                service.getNumBlocksOfPhaseStart(Cycles.Phase.BREAK1));
+        assertEquals(0, service.getNumBlocksOfPhaseStart(PeriodService.Phase.PROPOSAL));
+        assertEquals(PeriodService.Phase.PROPOSAL.getDurationInBlocks(),
+                service.getNumBlocksOfPhaseStart(PeriodService.Phase.BREAK1));
     }
 
     @Test
     public void isInCurrentCycleTest() {
         //int txHeight, int chainHeight, int genesisHeight, int numBlocksOfCycle
-//        int gen = 1;
-//        int numBlocksOfCycle = service.getNumBlocksOfCycle();
-//        assertFalse(service.isTxInCorrectCycle(gen, gen + numBlocksOfCycle, gen, numBlocksOfCycle));
-//
-//        assertFalse(service.isTxInCorrectCycle(gen - 1, gen - 1, gen, numBlocksOfCycle));
-//        assertFalse(service.isTxInCorrectCycle(gen, gen - 1, gen, numBlocksOfCycle));
-//        assertFalse(service.isTxInCorrectCycle(gen - 1, gen, gen, numBlocksOfCycle));
-//        assertTrue(service.isTxInCorrectCycle(gen, gen, gen, numBlocksOfCycle));
-//        assertTrue(service.isTxInCorrectCycle(gen, gen + 1, gen, numBlocksOfCycle));
-//        assertTrue(service.isTxInCorrectCycle(gen, gen + numBlocksOfCycle - 1, gen, numBlocksOfCycle));
-//
-//        assertTrue(service.isTxInCorrectCycle(gen, gen + numBlocksOfCycle - 1, gen, numBlocksOfCycle));
-//        assertTrue(service.isTxInCorrectCycle(gen + 1, gen + numBlocksOfCycle - 1, gen, numBlocksOfCycle));
-//        assertTrue(service.isTxInCorrectCycle(gen + numBlocksOfCycle - 1, gen + numBlocksOfCycle - 1, gen, numBlocksOfCycle));
-//        assertFalse(service.isTxInCorrectCycle(gen + numBlocksOfCycle, gen + numBlocksOfCycle - 1, gen, numBlocksOfCycle));
+        int gen = 1;
+        int numBlocksOfCycle = service.getNumBlocksOfCycle();
+        assertFalse(service.isTxInCorrectCycle(gen, gen + numBlocksOfCycle, gen, numBlocksOfCycle));
+
+        assertFalse(service.isTxInCorrectCycle(gen - 1, gen - 1, gen, numBlocksOfCycle));
+        assertFalse(service.isTxInCorrectCycle(gen, gen - 1, gen, numBlocksOfCycle));
+        assertFalse(service.isTxInCorrectCycle(gen - 1, gen, gen, numBlocksOfCycle));
+        assertTrue(service.isTxInCorrectCycle(gen, gen, gen, numBlocksOfCycle));
+        assertTrue(service.isTxInCorrectCycle(gen, gen + 1, gen, numBlocksOfCycle));
+        assertTrue(service.isTxInCorrectCycle(gen, gen + numBlocksOfCycle - 1, gen, numBlocksOfCycle));
+
+        assertTrue(service.isTxInCorrectCycle(gen, gen + numBlocksOfCycle - 1, gen, numBlocksOfCycle));
+        assertTrue(service.isTxInCorrectCycle(gen + 1, gen + numBlocksOfCycle - 1, gen, numBlocksOfCycle));
+        assertTrue(service.isTxInCorrectCycle(gen + numBlocksOfCycle - 1, gen + numBlocksOfCycle - 1, gen, numBlocksOfCycle));
+        assertFalse(service.isTxInCorrectCycle(gen + numBlocksOfCycle, gen + numBlocksOfCycle - 1, gen, numBlocksOfCycle));
     }
 }


### PR DESCRIPTION
Reverts ManfredKarrer/bisq-core#1

Tested with both old version and complete new setup (new genesis and new apps) but in both cases there are plenty of issues. Also as discussed we might move that data structure to the blocks directly so that would change again quite a bit. As the current version works without known bugs I will revert that PR and build on top of the existing version and move to the new data structure. 