### PR TITLE
Handle all unexpected cases of bad genesis tx output sums

### DIFF
--- a/src/main/java/bisq/core/dao/node/parser/GenesisTxParser.java
+++ b/src/main/java/bisq/core/dao/node/parser/GenesisTxParser.java
@@ -41,19 +41,22 @@ public class GenesisTxParser {
 
         TempTx tempTx = TempTx.fromRawTx(rawTx);
         tempTx.setTxType(TxType.GENESIS);
-        long availableInputValue = genesisTotalSupply.getValue();
+        long remainingInputValue = genesisTotalSupply.getValue();
         for (int i = 0; i < tempTx.getTempTxOutputs().size(); ++i) {
             TempTxOutput txOutput = tempTx.getTempTxOutputs().get(i);
             long value = txOutput.getValue();
-            boolean isValid = value <= availableInputValue;
+            boolean isValid = value <= remainingInputValue;
             if (!isValid)
-                throw new InvalidGenesisTxException("Genesis tx is isValid. " +
-                        "availableInputValue=" + availableInputValue + "; txOutput=" + txOutput.toString());
+                throw new InvalidGenesisTxException("Genesis tx is invalid; using more than available inputs. " +
+                        "Remaining input value is " + remainingInputValue + " sat; tx info: " + tempTx.toString());
 
-            availableInputValue -= value;
+            remainingInputValue -= value;
             txOutput.setTxOutputType(TxOutputType.GENESIS_OUTPUT);
         }
-
+        if (remainingInputValue > 0) {
+            throw new InvalidGenesisTxException("Genesis tx is invalid; not using all available inputs. " +
+                    "Remaining input value is " + remainingInputValue + " sat, tx info: " + tempTx.toString());
+        }
         return Optional.of(Tx.fromTempTx(tempTx));
     }
 }


### PR DESCRIPTION
Reformat exception messages for more clarity.

Also rename availableInputValue variable to remainingInputValue for clarity of its purpose.

Update the tests to conform to this more strict logic, and add new test cases for "tx outputs
too low / high" case.