### PR TITLE
Remove need for TxParser to know about BsqStateService

### DIFF
--- a/src/main/java/bisq/core/dao/node/parser/BlockParser.java
+++ b/src/main/java/bisq/core/dao/node/parser/BlockParser.java
@@ -99,7 +99,12 @@ public class BlockParser {
         // Lately there is a patter with 24 iterations observed
         long startTs = System.currentTimeMillis();
         List<Tx> txList = block.getTxs();
-        rawBlock.getRawTxs().forEach(rawTx -> txParser.findTx(rawTx).ifPresent(txList::add));
+
+        rawBlock.getRawTxs().forEach(rawTx -> txParser.findTx(
+                rawTx,
+                bsqStateService.getGenesisTxId(),
+                bsqStateService.getGenesisBlockHeight(),
+                bsqStateService.getGenesisTotalSupply()).ifPresent(txList::add));
         log.debug("parseBsqTxs took {} ms", rawBlock.getRawTxs().size(), System.currentTimeMillis() - startTs);
 
         bsqStateService.onParseBlockComplete(block);

--- a/src/test/java/bisq/core/dao/node/full/BlockParserTest.java
+++ b/src/test/java/bisq/core/dao/node/full/BlockParserTest.java
@@ -131,13 +131,17 @@ public class BlockParserTest {
             result = Optional.empty();
             result = Optional.of(new RawTxOutput(0, 100, "txout2", null, null, null, height));
         }};
+        String genesisTxId = "genesisTxId";
+        int blockHeight = 200;
+        String blockHash = "abc123";
+        Coin genesisTotalSupply = Coin.parseCoin("2.5");
 
         // First time there is no BSQ value to spend so it's not a bsq transaction
-        assertFalse(txParser.findTx(rawTx).isPresent());
+        assertFalse(txParser.findTx(rawTx, genesisTxId, blockHeight, genesisTotalSupply).isPresent());
         // Second time there is BSQ in the first txout
-        assertTrue(txParser.findTx(rawTx).isPresent());
+        assertTrue(txParser.findTx(rawTx, genesisTxId, blockHeight, genesisTotalSupply).isPresent());
         // Third time there is BSQ in the second txout
-        assertTrue(txParser.findTx(rawTx).isPresent());
+        assertTrue(txParser.findTx(rawTx, genesisTxId, blockHeight, genesisTotalSupply).isPresent());
     }
 
     @Test


### PR DESCRIPTION
By passing in the parameters we used to look up in BsqStateService
as arguments to findTx(), we remove the dependency on it.

Also make TxParser.getTxType(), getTxTypeForOpReturn() and getOptionalOpReturnType()
static, since they don't depend on any instance variables in TxParser.